### PR TITLE
Bugfix using translatePluralized on a boolean var.

### DIFF
--- a/src/ContaoCommunityAlliance/Translator/TranslatorChain.php
+++ b/src/ContaoCommunityAlliance/Translator/TranslatorChain.php
@@ -157,7 +157,7 @@ class TranslatorChain
 		$original = $string;
 
 		for ($translator = reset($this->translators);
-			$this->keepGoing || $string == $original;
+			$translator && ($this->keepGoing || $string == $original);
 			$translator = next($this->translators))
 		{
 			$string = $translator->translatePluralized($string, $number, $domain, $parameters, $locale);


### PR DESCRIPTION
This should fix the problem with 

Fatal error: Call to a member function translatePluralized() on a non-object in [...]/composer/vendor/contao-community-alliance/translator/src/ContaoCommunityAlliance/Translator/TranslatorChain.php on line 163
