### PR TITLE
Require events-contao-bindings.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     "php": ">=5.3",
     "contao/core": ">=3.2,<3.6-dev",
     "contao-community-alliance/composer-plugin": "~2.0",
-    "contao-community-alliance/event-dispatcher": "~1.0"
+    "contao-community-alliance/event-dispatcher": "~1.0",
+    "contao-community-alliance/events-contao-bindings": "~3.0"
   },
   "require-dev": {
     "phpcq/all-tasks": "~1.0"


### PR DESCRIPTION
The translator uses the events contao bindings but does not have set the dependency.