### PR TITLE
Restore compatibility with Contao 4.8

### DIFF
--- a/src/CcaTranslatorBundle.php
+++ b/src/CcaTranslatorBundle.php
@@ -10,7 +10,8 @@
  * @package    contao-community-alliance/event-dispatcher
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
- * @copyright  2013-2018 Contao Community Alliance <https://c-c-a.org>
+ * @author     David Molineus <david.molineus@netzmacht.de>
+ * @copyright  2013-2019 Contao Community Alliance <https://c-c-a.org>
  * @license    https://github.com/contao-community-alliance/event-dispatcher/LICENSE LGPL-3.0+
  * @link       https://github.com/contao-community-alliance/event-dispatcher
  * @filesource
@@ -18,6 +19,8 @@
 
 namespace ContaoCommunityAlliance\Translator;
 
+use ContaoCommunityAlliance\Translator\DependencyInjection\Compiler\RegisterBackportTranslatorPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -25,4 +28,11 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class CcaTranslatorBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new RegisterBackportTranslatorPass());
+    }
 }

--- a/src/DependencyInjection/Compiler/RegisterBackportTranslatorPass.php
+++ b/src/DependencyInjection/Compiler/RegisterBackportTranslatorPass.php
@@ -11,8 +11,6 @@
  * This project is provided in good faith and hope to be usable by anyone.
  *
  * @package    contao-community-alliance/dependency-container
- * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
- * @author     Sven Baumann <baumann.sv@gmail.com>
  * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  2013-2019 Contao Community Alliance <https://c-c-a.org>
  * @license    https://github.com/contao-community-alliance/dependency-container/blob/master/LICENSE LGPL-3.0
@@ -20,24 +18,24 @@
  * @filesource
  */
 
-namespace ContaoCommunityAlliance\Translator\DependencyInjection;
+namespace ContaoCommunityAlliance\Translator\DependencyInjection\Compiler;
 
-use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Extension\Extension;
-use Symfony\Component\DependencyInjection\Loader;
 
 /**
- * This is the class that loads and manages the bundle configuration
+ * This compiler pass sets the alias to contao.translation.translator and defines the decorated class
  */
-class CcaTranslatorExtension extends Extension
+class RegisterBackportTranslatorPass implements CompilerPassInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function process(ContainerBuilder $container)
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
-        $loader->load('services.yml');
+        if (!$container->hasDefinition('contao.translation.translator')) {
+            $container->getDefinition('cca.translator.backport45translator')->setDecoratedService('translator');
+            $container->setAlias('contao.translation.translator', 'cca.translator.backport45translator');
+        }
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -10,7 +10,6 @@ services:
 
     cca.translator.backport45translator:
         class: ContaoCommunityAlliance\Translator\BackportedTranslator
-        decorates: translator
         arguments:
             - "@cca.translator.backport45translator.inner"
             - "@contao.framework"


### PR DESCRIPTION
Until now the alias of the backported translator was always set because
the container builder in the extension only has access to it's own
service definitions and not to all one. That's why the alias definition
has to move to a compiler pass.

It also changes when the cca backport translator decorates the symfony
translator: It now only happens if the Contao translator is not
available.

See #8 