### PR TITLE
[RTM] Fix incompatibilities with PCRE 8.32 in the BackportedTranslator class

### DIFF
--- a/src/BackportedTranslator.php
+++ b/src/BackportedTranslator.php
@@ -125,8 +125,8 @@ class BackportedTranslator implements SymfonyTranslatorInterface
     private function getFromGlobals($id)
     {
         // Split the ID into chunks allowing escaped dots (\.) and backslashes (\\)
-        preg_match_all('/(?:\\\\[.\\\\]|[^.])++/s', $id, $matches);
-        $parts = preg_replace('/\\\\([.\\\\])/s', '$1', $matches[0]);
+        preg_match_all('/(?:\\\\[\\\\.]|[^.])++/', $id, $matches);
+        $parts = preg_replace('/\\\\([\\\\.])/', '$1', $matches[0]);
         $item  = &$GLOBALS['TL_LANG'];
         foreach ($parts as $part) {
             if (!isset($item[$part])) {

--- a/src/BackportedTranslator.php
+++ b/src/BackportedTranslator.php
@@ -13,6 +13,7 @@
  * @package    contao-community-alliance/translator
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
  * @author     Sven Baumann <baumann.sv@gmail.com>
+ * @author     Philipp Lorenz <philipp.lorenz@etes.de>
  * @copyright  2013-2018 Contao Community Alliance.
  * @license    https://github.com/contao-community-alliance/translator/blob/master/LICENSE LGPL-3.0
  * @filesource


### PR DESCRIPTION
Due to a regression in PCRE 8.32 there is a problem using the translator on systems using this version of the library. Some regular expressions can't be parsed which breaks functionality. As a result, e.g. using MetaModels isn't possible because every translation returned has the value 'Array'.

In Contao 4.5, the Translator class was introduced and ran into this problem: https://github.com/contao/contao/issues/886
Since the BackportedTranslator class in this project uses parts of the code from the original Contao Translator class, I think the changes made here to Translator.php should also be made to the BackportedTranslator class: https://github.com/contao/contao/pull/916

Changing these two lines in a test installation environment fixes the problem instantly for me.